### PR TITLE
Feat: implementa CRUD de mangas

### DIFF
--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
@@ -44,4 +44,10 @@ public class MangaController {
 
         return ResponseEntity.created(uri).body(mangaCriado);
     }
+
+    @DeleteMapping(value = "/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id){
+        mangaService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
@@ -2,6 +2,8 @@ package dev.flmelo.mangakeeper.backend.controller;
 
 import dev.flmelo.mangakeeper.backend.dto.manga.CreateMangaDTO;
 import dev.flmelo.mangakeeper.backend.dto.manga.MangaResponseDTO;
+import dev.flmelo.mangakeeper.backend.dto.manga.UpdateMangaDTO;
+import dev.flmelo.mangakeeper.backend.entity.Manga;
 import dev.flmelo.mangakeeper.backend.service.MangaService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -43,6 +45,12 @@ public class MangaController {
                 .toUri();
 
         return ResponseEntity.created(uri).body(mangaCriado);
+    }
+
+    @PatchMapping(value = "/{id}")
+    public ResponseEntity<MangaResponseDTO> updateManga(@Valid @PathVariable Long id, @RequestBody UpdateMangaDTO request){
+        MangaResponseDTO manga = mangaService.update(id, request);
+        return ResponseEntity.ok().body(manga);
     }
 
     @DeleteMapping(value = "/{id}")

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
@@ -1,0 +1,16 @@
+package dev.flmelo.mangakeeper.backend.controller;
+
+import dev.flmelo.mangakeeper.backend.service.MangaService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "mangas")
+public class MangaController {
+
+    private final MangaService mangaService;
+
+    public MangaController(MangaService mangaService) {
+        this.mangaService = mangaService;
+    }
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
@@ -1,8 +1,13 @@
 package dev.flmelo.mangakeeper.backend.controller;
 
+import dev.flmelo.mangakeeper.backend.dto.manga.MangaResponseDTO;
 import dev.flmelo.mangakeeper.backend.service.MangaService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping(value = "mangas")
@@ -13,4 +18,12 @@ public class MangaController {
     public MangaController(MangaService mangaService) {
         this.mangaService = mangaService;
     }
+
+    @GetMapping
+    public ResponseEntity<List<MangaResponseDTO>> getAll(){
+        List<MangaResponseDTO> list = mangaService.getAll();
+        return ResponseEntity.ok().body(list);
+    }
+
+
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
@@ -1,13 +1,14 @@
 package dev.flmelo.mangakeeper.backend.controller;
 
+import dev.flmelo.mangakeeper.backend.dto.manga.CreateMangaDTO;
 import dev.flmelo.mangakeeper.backend.dto.manga.MangaResponseDTO;
 import dev.flmelo.mangakeeper.backend.service.MangaService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -30,5 +31,17 @@ public class MangaController {
     public ResponseEntity<MangaResponseDTO> getById(@PathVariable Long id){
         MangaResponseDTO manga = mangaService.getById(id);
         return ResponseEntity.ok().body(manga);
+    }
+
+    @PostMapping
+    public ResponseEntity<MangaResponseDTO> create(@Valid @RequestBody CreateMangaDTO request){
+        MangaResponseDTO mangaCriado = mangaService.create(request);
+        URI uri = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(mangaCriado.id())
+                .toUri();
+
+        return ResponseEntity.created(uri).body(mangaCriado);
     }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/MangaController.java
@@ -4,6 +4,7 @@ import dev.flmelo.mangakeeper.backend.dto.manga.MangaResponseDTO;
 import dev.flmelo.mangakeeper.backend.service.MangaService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,5 +26,9 @@ public class MangaController {
         return ResponseEntity.ok().body(list);
     }
 
-
+    @GetMapping(value = "/{id}")
+    public ResponseEntity<MangaResponseDTO> getById(@PathVariable Long id){
+        MangaResponseDTO manga = mangaService.getById(id);
+        return ResponseEntity.ok().body(manga);
+    }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/CreateMangaDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/CreateMangaDTO.java
@@ -1,0 +1,21 @@
+package dev.flmelo.mangakeeper.backend.dto.manga;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.flmelo.mangakeeper.backend.entity.enuns.Idioma;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateMangaDTO(
+        @NotBlank String titulo,
+        @NotBlank String autor,
+        @NotBlank String editora,
+        @NotBlank String genero,
+        @NotBlank String sinopse,
+        String issn,
+        @JsonProperty("total_volumes")
+        @NotNull Integer totalVolumes,
+        @NotNull Idioma idioma,
+        @NotNull Long colecaoId
+
+        ) {
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/MangaResponseDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/MangaResponseDTO.java
@@ -1,0 +1,19 @@
+package dev.flmelo.mangakeeper.backend.dto.manga;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.flmelo.mangakeeper.backend.entity.enuns.Idioma;
+
+public record MangaResponseDTO(
+        Long id,
+        String titulo,
+        String autor,
+        String editora,
+        String genero,
+        String sinopse,
+        String issn,
+        @JsonProperty(value = "total_volumes")
+        Integer totalVolumes,
+        Idioma idioma,
+        Long colecaoId
+) {
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/MangaResponseDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/MangaResponseDTO.java
@@ -14,6 +14,7 @@ public record MangaResponseDTO(
         @JsonProperty(value = "total_volumes")
         Integer totalVolumes,
         Idioma idioma,
+        @JsonProperty("colecao_id")
         Long colecaoId
 ) {
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/UpdateMangaDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/UpdateMangaDTO.java
@@ -1,0 +1,17 @@
+package dev.flmelo.mangakeeper.backend.dto.manga;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.flmelo.mangakeeper.backend.entity.enuns.Idioma;
+
+public record UpdateMangaDTO(
+        String titulo,
+        String autor,
+        String editora,
+        String genero,
+        String sinopse,
+        String issn,
+        @JsonProperty(value = "total_volumes")
+        Integer totalVolumes,
+        Idioma idioma
+) {
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/UpdateMangaDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/UpdateMangaDTO.java
@@ -2,6 +2,7 @@ package dev.flmelo.mangakeeper.backend.dto.manga;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.flmelo.mangakeeper.backend.entity.enuns.Idioma;
+import jakarta.validation.constraints.Positive;
 
 public record UpdateMangaDTO(
         String titulo,
@@ -10,6 +11,7 @@ public record UpdateMangaDTO(
         String genero,
         String sinopse,
         String issn,
+        @Positive
         @JsonProperty(value = "total_volumes")
         Integer totalVolumes,
         Idioma idioma

--- a/src/main/java/dev/flmelo/mangakeeper/backend/entity/Manga.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/entity/Manga.java
@@ -32,6 +32,7 @@ public class Manga {
     private String genero;
 
     @NotBlank
+    @Column(columnDefinition = "TEXT")
     private String sinopse;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/dev/flmelo/mangakeeper/backend/repository/MangaRepository.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/repository/MangaRepository.java
@@ -1,0 +1,7 @@
+package dev.flmelo.mangakeeper.backend.repository;
+
+import dev.flmelo.mangakeeper.backend.entity.Manga;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MangaRepository extends JpaRepository<Manga, Long> {
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
@@ -106,7 +106,62 @@ public class MangaService {
     }
 
     public MangaResponseDTO update(Long id, UpdateMangaDTO request){
+        Optional<Manga> mangaById = mangaRepository.findById(id);
+        if (mangaById.isEmpty()){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Mangá não encontrada.");
+        }
+        Manga m = mangaById.get();
 
+        if (request.titulo() != null){
+            String titulo = clean(request.titulo());
+            m.setTitulo(titulo);
+        }
+        if (request.autor() != null){
+            String autor = clean(request.autor());
+            m.setAutor(autor);
+        }
+        if (request.editora() != null){
+            String editora = clean(request.editora());
+            m.setEditora(editora);
+        }
+        if (request.genero() != null){
+            String genero = clean(request.genero());
+            m.setGenero(genero);
+        }
+        if (request.sinopse() != null){
+            String sinopse = clean(request.sinopse());
+            m.setSinopse(sinopse);
+        }
+        if (request.issn() != null){
+            String issn = clean(request.issn());
+            m.setIssn(issn);
+        }
+        if (request.totalVolumes() != null){
+            m.setTotalVolumes(request.totalVolumes());
+        }
+        if (request.idioma() != null){
+            m.setIdioma(request.idioma());
+        }
+
+        Manga mangaSalvo = mangaRepository.save(m);
+
+        return new MangaResponseDTO(
+                mangaSalvo.getId(),
+                mangaSalvo.getTitulo(),
+                mangaSalvo.getAutor(),
+                mangaSalvo.getEditora(),
+                mangaSalvo.getGenero(),
+                mangaSalvo.getSinopse(),
+                mangaSalvo.getIssn(),
+                mangaSalvo.getTotalVolumes(),
+                mangaSalvo.getIdioma(),
+                mangaSalvo.getColecao().getId()
+        );
+
+    }
+
+    private String clean(String titulo) {
+        return titulo.trim();
     }
 
     public void delete(Long id){

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
@@ -1,10 +1,14 @@
 package dev.flmelo.mangakeeper.backend.service;
 
 import dev.flmelo.mangakeeper.backend.dto.manga.MangaResponseDTO;
+import dev.flmelo.mangakeeper.backend.entity.Manga;
 import dev.flmelo.mangakeeper.backend.repository.MangaRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class MangaService {
@@ -30,5 +34,25 @@ public class MangaService {
                         manga.getIdioma(),
                         manga.getColecao().getId()
                 )).toList();
+    }
+
+    public MangaResponseDTO getById(Long id){
+        Optional<Manga> mangaById = mangaRepository.findById(id);
+        if (mangaById.isEmpty()){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Mangá não encontrado.");
+        }
+        Manga manga = mangaById.get();
+        return new MangaResponseDTO(
+                manga.getId(),
+                manga.getTitulo(),
+                manga.getAutor(),
+                manga.getEditora(),
+                manga.getGenero(),
+                manga.getSinopse(),
+                manga.getIssn(),
+                manga.getTotalVolumes(),
+                manga.getIdioma(),
+                manga.getColecao().getId()
+        );
     }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
@@ -1,7 +1,10 @@
 package dev.flmelo.mangakeeper.backend.service;
 
+import dev.flmelo.mangakeeper.backend.dto.manga.MangaResponseDTO;
 import dev.flmelo.mangakeeper.backend.repository.MangaRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class MangaService {
@@ -10,5 +13,22 @@ public class MangaService {
 
     public MangaService(MangaRepository mangaRepository) {
         this.mangaRepository = mangaRepository;
+    }
+
+    public List<MangaResponseDTO> getAll(){
+        return mangaRepository.findAll()
+                .stream()
+                .map(manga ->  new MangaResponseDTO(
+                        manga.getId(),
+                        manga.getTitulo(),
+                        manga.getAutor(),
+                        manga.getEditora(),
+                        manga.getGenero(),
+                        manga.getSinopse(),
+                        manga.getIssn(),
+                        manga.getTotalVolumes(),
+                        manga.getIdioma(),
+                        manga.getColecao().getId()
+                )).toList();
     }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
@@ -1,0 +1,14 @@
+package dev.flmelo.mangakeeper.backend.service;
+
+import dev.flmelo.mangakeeper.backend.repository.MangaRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MangaService {
+
+    private final MangaRepository mangaRepository;
+
+    public MangaService(MangaRepository mangaRepository) {
+        this.mangaRepository = mangaRepository;
+    }
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
@@ -103,4 +103,14 @@ public class MangaService {
         );
 
     }
+
+    public MangaResponseDTO update(Long id, )
+
+    public void delete(Long id){
+        Optional<Manga> manga = mangaRepository.findById(id);
+        if (manga.isEmpty()){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Mangá não encontrada.");
+        }
+        mangaRepository.deleteById(id);
+    }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
@@ -2,6 +2,7 @@ package dev.flmelo.mangakeeper.backend.service;
 
 import dev.flmelo.mangakeeper.backend.dto.manga.CreateMangaDTO;
 import dev.flmelo.mangakeeper.backend.dto.manga.MangaResponseDTO;
+import dev.flmelo.mangakeeper.backend.dto.manga.UpdateMangaDTO;
 import dev.flmelo.mangakeeper.backend.entity.Colecao;
 import dev.flmelo.mangakeeper.backend.entity.Manga;
 import dev.flmelo.mangakeeper.backend.repository.ColecaoRepository;
@@ -104,7 +105,9 @@ public class MangaService {
 
     }
 
-    public MangaResponseDTO update(Long id, )
+    public MangaResponseDTO update(Long id, UpdateMangaDTO request){
+
+    }
 
     public void delete(Long id){
         Optional<Manga> manga = mangaRepository.findById(id);

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
@@ -1,7 +1,10 @@
 package dev.flmelo.mangakeeper.backend.service;
 
+import dev.flmelo.mangakeeper.backend.dto.manga.CreateMangaDTO;
 import dev.flmelo.mangakeeper.backend.dto.manga.MangaResponseDTO;
+import dev.flmelo.mangakeeper.backend.entity.Colecao;
 import dev.flmelo.mangakeeper.backend.entity.Manga;
+import dev.flmelo.mangakeeper.backend.repository.ColecaoRepository;
 import dev.flmelo.mangakeeper.backend.repository.MangaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -14,9 +17,11 @@ import java.util.Optional;
 public class MangaService {
 
     private final MangaRepository mangaRepository;
+    private final ColecaoRepository colecaoRepository;
 
-    public MangaService(MangaRepository mangaRepository) {
+    public MangaService(MangaRepository mangaRepository, ColecaoRepository colecaoRepository) {
         this.mangaRepository = mangaRepository;
+        this.colecaoRepository = colecaoRepository;
     }
 
     public List<MangaResponseDTO> getAll(){
@@ -54,5 +59,48 @@ public class MangaService {
                 manga.getIdioma(),
                 manga.getColecao().getId()
         );
+    }
+
+    public MangaResponseDTO create(CreateMangaDTO request){
+        Optional<Colecao> colecao = colecaoRepository.findById(request.colecaoId());
+        if (colecao.isEmpty()){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Coleção não encontrada.");
+        }
+        Colecao c = colecao.get();
+
+        String issn = request.issn();
+        if (issn != null && issn.trim().isEmpty()){
+            issn = null;
+        }
+
+        Manga manga = new Manga(
+                request.titulo(),
+                issn,
+                request.autor(),
+                request.editora(),
+                request.genero(),
+                request.sinopse(),
+                request.idioma(),
+                request.totalVolumes(),
+                c
+        );
+
+
+
+        Manga mangaSalvo = mangaRepository.save(manga);
+
+        return new MangaResponseDTO(
+                mangaSalvo.getId(),
+                mangaSalvo.getTitulo().trim(),
+                mangaSalvo.getAutor().trim(),
+                mangaSalvo.getEditora().trim(),
+                mangaSalvo.getGenero().trim(),
+                mangaSalvo.getSinopse().trim(),
+                mangaSalvo.getIssn(),
+                mangaSalvo.getTotalVolumes(),
+                mangaSalvo.getIdioma(),
+                mangaSalvo.getColecao().getId()
+        );
+
     }
 }


### PR DESCRIPTION
## O que foi feito
- CRUD de mangas
- Endpoint de criação, listagem, atualização e deleção

## Estrutura
- Controller para endpoints REST
- Service com regras de negócio
- Repository com JPA
- DTOs de entrada e saída

## Regras aplicadas
- Validação com Bean Validation (@NotBlank, @Positive, etc.)
- Associação obrigatória com coleção
- Normalização de strings (trim)

## Como testar
1. Criar uma coleção no banco
2. Fazer POST /mangas
3. Testar GET, PATCH, DELETE
4. Validar erros (ex: total_volumes <= 0)

## Observações
- Atualização parcial implementada (PATCH)
- Campo coleção não pode ser alterado após criação

## Issue relacionada
#7 