### PR TITLE
Feat: implementa CRUD de volumes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
 
 
 		<dependency>

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
@@ -4,6 +4,7 @@ import dev.flmelo.mangakeeper.backend.dto.volume.VolumeResponseDTO;
 import dev.flmelo.mangakeeper.backend.service.VolumeService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +24,11 @@ public class VolumeController {
     public ResponseEntity<List<VolumeResponseDTO>> getAll(){
         List<VolumeResponseDTO> list = volumeService.getAll();
         return ResponseEntity.ok().body(list);
+    }
+
+    @GetMapping(value = "/{id}")
+    public ResponseEntity<VolumeResponseDTO> getById(@PathVariable Long id){
+        VolumeResponseDTO volumeById = volumeService.getById(id);
+        return ResponseEntity.ok().body(volumeById);
     }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
@@ -1,10 +1,14 @@
 package dev.flmelo.mangakeeper.backend.controller;
 
+import dev.flmelo.mangakeeper.backend.dto.volume.CreateVolumeDTO;
 import dev.flmelo.mangakeeper.backend.dto.volume.VolumeResponseDTO;
 import dev.flmelo.mangakeeper.backend.service.VolumeService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
@@ -29,6 +33,16 @@ public class VolumeController {
         return ResponseEntity.ok().body(volumeById);
     }
 
+    @PostMapping
+    public ResponseEntity<VolumeResponseDTO> create(@Valid @RequestBody CreateVolumeDTO request){
+        VolumeResponseDTO volumeCriado = volumeService.create(request);
+        URI uri = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(volumeCriado.id())
+                .toUri();
+        return ResponseEntity.created(uri).body(volumeCriado);
+    }
 
 
     @DeleteMapping (value = "/{id}")

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
@@ -1,0 +1,27 @@
+package dev.flmelo.mangakeeper.backend.controller;
+
+import dev.flmelo.mangakeeper.backend.dto.volume.VolumeResponseDTO;
+import dev.flmelo.mangakeeper.backend.service.VolumeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value = "volumes")
+public class VolumeController {
+
+    public VolumeController(VolumeService volumeService) {
+        this.volumeService = volumeService;
+    }
+
+    private final VolumeService volumeService;
+
+    @GetMapping
+    public ResponseEntity<List<VolumeResponseDTO>> getAll(){
+        List<VolumeResponseDTO> list = volumeService.getAll();
+        return ResponseEntity.ok().body(list);
+    }
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
@@ -1,6 +1,7 @@
 package dev.flmelo.mangakeeper.backend.controller;
 
 import dev.flmelo.mangakeeper.backend.dto.volume.CreateVolumeDTO;
+import dev.flmelo.mangakeeper.backend.dto.volume.UpdateVolumeDTO;
 import dev.flmelo.mangakeeper.backend.dto.volume.VolumeResponseDTO;
 import dev.flmelo.mangakeeper.backend.service.VolumeService;
 import jakarta.validation.Valid;
@@ -42,6 +43,12 @@ public class VolumeController {
                 .buildAndExpand(volumeCriado.id())
                 .toUri();
         return ResponseEntity.created(uri).body(volumeCriado);
+    }
+
+    @PatchMapping(value = "/{id}")
+    public ResponseEntity<VolumeResponseDTO> update(@Valid @PathVariable Long id, @RequestBody UpdateVolumeDTO request){
+        VolumeResponseDTO volume = volumeService.update(id, request);
+        return ResponseEntity.ok().body(volume);
     }
 
 

--- a/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/controller/VolumeController.java
@@ -3,10 +3,7 @@ package dev.flmelo.mangakeeper.backend.controller;
 import dev.flmelo.mangakeeper.backend.dto.volume.VolumeResponseDTO;
 import dev.flmelo.mangakeeper.backend.service.VolumeService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -30,5 +27,13 @@ public class VolumeController {
     public ResponseEntity<VolumeResponseDTO> getById(@PathVariable Long id){
         VolumeResponseDTO volumeById = volumeService.getById(id);
         return ResponseEntity.ok().body(volumeById);
+    }
+
+
+
+    @DeleteMapping (value = "/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id){
+        volumeService.delete(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/CreateMangaDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/manga/CreateMangaDTO.java
@@ -15,7 +15,8 @@ public record CreateMangaDTO(
         @JsonProperty("total_volumes")
         @NotNull Integer totalVolumes,
         @NotNull Idioma idioma,
-        @NotNull Long colecaoId
+
+        @JsonProperty("colecao_id") @NotNull Long colecaoId
 
         ) {
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/volume/CreateVolumeDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/volume/CreateVolumeDTO.java
@@ -3,14 +3,16 @@ package dev.flmelo.mangakeeper.backend.dto.volume;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record CreateVolumeDTO(
-        @NotNull Integer numero,
+
+        @Positive @NotNull Integer numero,
 
         @JsonProperty("codigo_de_barras")
         @NotBlank String codigoDeBarras,
 
-        @NotBlank String isbn,
+        String isbn,
 
         @NotNull @JsonProperty("manga_id") Long mangaId,
 

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/volume/CreateVolumeDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/volume/CreateVolumeDTO.java
@@ -1,0 +1,20 @@
+package dev.flmelo.mangakeeper.backend.dto.volume;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateVolumeDTO(
+        @NotNull Integer numero,
+
+        @JsonProperty("codigo_de_barras")
+        @NotBlank String codigoDeBarras,
+
+        @NotBlank String isbn,
+
+        @NotNull @JsonProperty("manga_id") Long mangaId,
+
+        @NotNull @JsonProperty("imagem_url") String imagemUrl
+
+) {
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/volume/UpdateVolumeDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/volume/UpdateVolumeDTO.java
@@ -1,0 +1,20 @@
+package dev.flmelo.mangakeeper.backend.dto.volume;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Positive;
+
+public record UpdateVolumeDTO(
+
+        @Positive
+        Integer numero,
+
+        @JsonProperty("codigo_de_barras")
+        String codigoDeBarras,
+
+        String isbn,
+
+        @JsonProperty("imagem_url")
+        String imagemUrl
+
+        ) {
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/dto/volume/VolumeResponseDTO.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/dto/volume/VolumeResponseDTO.java
@@ -1,0 +1,15 @@
+package dev.flmelo.mangakeeper.backend.dto.volume;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record VolumeResponseDTO(
+        Long id,
+        Integer numero,
+        String codigoDeBarras,
+        String isbn,
+        @JsonProperty("manga_id")
+        Long mangaId,
+        @JsonProperty("imagem_url")
+        String imagemUrl
+) {
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/exceptions/MangaNotFoundException.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/exceptions/MangaNotFoundException.java
@@ -1,0 +1,7 @@
+package dev.flmelo.mangakeeper.backend.exceptions;
+
+public class MangaNotFoundException extends RuntimeException{
+    public MangaNotFoundException() { super("Mangá não Encontrado");}
+
+    public MangaNotFoundException(String message) { super(message);}
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestErrorMessage.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestErrorMessage.java
@@ -1,0 +1,13 @@
+package dev.flmelo.mangakeeper.backend.infra;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public class RestErrorMessage {
+    private HttpStatus status;
+    private String message;
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestExceptionHandler.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestExceptionHandler.java
@@ -11,28 +11,38 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(UserNotFoundException.class)
-    private ResponseEntity<String> userNotFoundHandler(UserNotFoundException exception){
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+    private ResponseEntity<RestErrorMessage> userNotFoundHandler(UserNotFoundException exception){
+        HttpStatus status = HttpStatus.NOT_FOUND;
+        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(UserAlreadyExistsException.class)
-    private ResponseEntity<String> userAlreadyExistsHandler(UserAlreadyExistsException exception){
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(exception.getMessage());
+    private ResponseEntity<RestErrorMessage> userAlreadyExistsHandler(UserAlreadyExistsException exception){
+        HttpStatus status = HttpStatus.CONFLICT;
+        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(CollectionNotFoundException.class)
-    private ResponseEntity<String> colletionNotFoundHandler(CollectionNotFoundException exception){
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+    private ResponseEntity<RestErrorMessage> colletionNotFoundHandler(CollectionNotFoundException exception){
+        HttpStatus status = HttpStatus.NOT_FOUND;
+        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(InvalidCollectionNameException.class)
-    private ResponseEntity<String> invalidCollectionNameHandler(InvalidCollectionNameException exception){
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+    private ResponseEntity<RestErrorMessage> invalidCollectionNameHandler(InvalidCollectionNameException exception){
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(MangaNotFoundException.class)
-    private ResponseEntity<String> mangaNotFoundHandler(MangaNotFoundException exception){
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+    private ResponseEntity<RestErrorMessage> mangaNotFoundHandler(MangaNotFoundException exception){
+        HttpStatus status = HttpStatus.NOT_FOUND;
+        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        return ResponseEntity.status(status).body(errorResponse);
     }
 
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestExceptionHandler.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestExceptionHandler.java
@@ -1,9 +1,6 @@
 package dev.flmelo.mangakeeper.backend.infra;
 
-import dev.flmelo.mangakeeper.backend.exceptions.CollectionNotFoundException;
-import dev.flmelo.mangakeeper.backend.exceptions.InvalidCollectionNameException;
-import dev.flmelo.mangakeeper.backend.exceptions.UserAlreadyExistsException;
-import dev.flmelo.mangakeeper.backend.exceptions.UserNotFoundException;
+import dev.flmelo.mangakeeper.backend.exceptions.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -31,6 +28,11 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(InvalidCollectionNameException.class)
     private ResponseEntity<String> invalidCollectionNameHandler(InvalidCollectionNameException exception){
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
+    }
+
+    @ExceptionHandler(MangaNotFoundException.class)
+    private ResponseEntity<String> mangaNotFoundHandler(MangaNotFoundException exception){
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
     }
 
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/repository/ColecaoRepository.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/repository/ColecaoRepository.java
@@ -2,6 +2,8 @@ package dev.flmelo.mangakeeper.backend.repository;
 
 import dev.flmelo.mangakeeper.backend.entity.Colecao;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ColecaoRepository extends JpaRepository<Colecao, Long> {
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/repository/VolumeRepository.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/repository/VolumeRepository.java
@@ -1,9 +1,9 @@
 package dev.flmelo.mangakeeper.backend.repository;
 
-import dev.flmelo.mangakeeper.backend.entity.Manga;
+import dev.flmelo.mangakeeper.backend.entity.Volume;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MangaRepository extends JpaRepository<Manga, Long> {
+public interface VolumeRepository extends JpaRepository<Volume, Long> {
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/MangaService.java
@@ -5,6 +5,8 @@ import dev.flmelo.mangakeeper.backend.dto.manga.MangaResponseDTO;
 import dev.flmelo.mangakeeper.backend.dto.manga.UpdateMangaDTO;
 import dev.flmelo.mangakeeper.backend.entity.Colecao;
 import dev.flmelo.mangakeeper.backend.entity.Manga;
+import dev.flmelo.mangakeeper.backend.exceptions.CollectionNotFoundException;
+import dev.flmelo.mangakeeper.backend.exceptions.MangaNotFoundException;
 import dev.flmelo.mangakeeper.backend.repository.ColecaoRepository;
 import dev.flmelo.mangakeeper.backend.repository.MangaRepository;
 import org.springframework.http.HttpStatus;
@@ -45,7 +47,7 @@ public class MangaService {
     public MangaResponseDTO getById(Long id){
         Optional<Manga> mangaById = mangaRepository.findById(id);
         if (mangaById.isEmpty()){
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Mangá não encontrado.");
+            throw new MangaNotFoundException();
         }
         Manga manga = mangaById.get();
         return new MangaResponseDTO(
@@ -65,7 +67,7 @@ public class MangaService {
     public MangaResponseDTO create(CreateMangaDTO request){
         Optional<Colecao> colecao = colecaoRepository.findById(request.colecaoId());
         if (colecao.isEmpty()){
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Coleção não encontrada.");
+            throw new CollectionNotFoundException();
         }
         Colecao c = colecao.get();
 
@@ -108,7 +110,7 @@ public class MangaService {
     public MangaResponseDTO update(Long id, UpdateMangaDTO request){
         Optional<Manga> mangaById = mangaRepository.findById(id);
         if (mangaById.isEmpty()){
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Mangá não encontrada.");
+            throw new MangaNotFoundException();
         }
         Manga m = mangaById.get();
 
@@ -167,7 +169,7 @@ public class MangaService {
     public void delete(Long id){
         Optional<Manga> manga = mangaRepository.findById(id);
         if (manga.isEmpty()){
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Mangá não encontrada.");
+            throw new MangaNotFoundException();
         }
         mangaRepository.deleteById(id);
     }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
@@ -1,6 +1,7 @@
 package dev.flmelo.mangakeeper.backend.service;
 
 import dev.flmelo.mangakeeper.backend.dto.volume.CreateVolumeDTO;
+import dev.flmelo.mangakeeper.backend.dto.volume.UpdateVolumeDTO;
 import dev.flmelo.mangakeeper.backend.dto.volume.VolumeResponseDTO;
 import dev.flmelo.mangakeeper.backend.entity.Manga;
 import dev.flmelo.mangakeeper.backend.entity.Volume;
@@ -79,8 +80,37 @@ public class VolumeService {
                 volumeSalvo.getImagemUrl());
     }
 
-    private String clean(String s) {
-       return s == null ? null :  s.trim();
+    public VolumeResponseDTO update(Long id, UpdateVolumeDTO request){
+        Optional<Volume> volumeById = volumeRepository.findById(id);
+        if (volumeById.isEmpty()){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Volume não encontrado.");
+        }
+        Volume volumeAtualizado = new Volume();
+        if (request.numero() != null){
+            volumeAtualizado.setNumero(request.numero());
+        }
+        if (request.codigoDeBarras() != null){
+            String cdb = request.codigoDeBarras().trim();
+            volumeAtualizado.setCodigoDeBarras(cdb);
+        }
+        if (request.isbn() != null){
+            String isbn = request.isbn().trim();
+            volumeAtualizado.setIsbn(isbn);
+        }
+        if (request.imagemUrl() != null) {
+            String imgUrl = request.imagemUrl().trim();
+            volumeAtualizado.setImagemUrl(imgUrl);
+        }
+        Volume v = volumeRepository.save(volumeAtualizado);
+
+        return new VolumeResponseDTO(
+                v.getId(),
+                v.getNumero(),
+                v.getCodigoDeBarras(),
+                v.getIsbn(),
+                v.getManga().getId(),
+                v.getImagemUrl()
+        );
 
     }
 
@@ -90,5 +120,10 @@ public class VolumeService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Volume não encontrado.");
         }
         volumeRepository.deleteById(id);
+    }
+
+    private String clean(String s) {
+        return s == null ? null :  s.trim();
+
     }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
@@ -1,11 +1,13 @@
 package dev.flmelo.mangakeeper.backend.service;
 
+import dev.flmelo.mangakeeper.backend.dto.volume.CreateVolumeDTO;
 import dev.flmelo.mangakeeper.backend.dto.volume.VolumeResponseDTO;
+import dev.flmelo.mangakeeper.backend.entity.Manga;
 import dev.flmelo.mangakeeper.backend.entity.Volume;
+import dev.flmelo.mangakeeper.backend.exceptions.MangaNotFoundException;
 import dev.flmelo.mangakeeper.backend.repository.MangaRepository;
 import dev.flmelo.mangakeeper.backend.repository.VolumeRepository;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -51,7 +53,36 @@ public class VolumeService {
         );
     }
 
-    public VolumeResponseDTO()
+    public VolumeResponseDTO create(CreateVolumeDTO request){
+        Optional<Manga> manga = mangaRepository.findById(request.mangaId());
+        if (manga.isEmpty()){
+            throw new MangaNotFoundException();
+        }
+        Manga m = manga.get();
+
+        Volume volume = new Volume(
+                request.numero(),
+                clean(request.codigoDeBarras()),
+                clean(request.isbn()),
+                m,
+                clean(request.imagemUrl())
+        );
+
+        Volume volumeSalvo = volumeRepository.save(volume);
+
+        return new VolumeResponseDTO(
+                volumeSalvo.getId(),
+                volume.getNumero(),
+                volumeSalvo.getCodigoDeBarras(),
+                volumeSalvo.getIsbn(),
+                volumeSalvo.getManga().getId(),
+                volumeSalvo.getImagemUrl());
+    }
+
+    private String clean(String s) {
+       return s == null ? null :  s.trim();
+
+    }
 
     public void delete(Long id){
         Optional<Volume> volumeById = volumeRepository.findById(id);

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
@@ -1,0 +1,34 @@
+package dev.flmelo.mangakeeper.backend.service;
+
+import dev.flmelo.mangakeeper.backend.dto.volume.VolumeResponseDTO;
+import dev.flmelo.mangakeeper.backend.repository.MangaRepository;
+import dev.flmelo.mangakeeper.backend.repository.VolumeRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class VolumeService {
+    private final VolumeRepository volumeRepository;
+    private final MangaRepository mangaRepository;
+
+    public VolumeService(VolumeRepository volumeRepository, MangaRepository mangaRepository) {
+        this.volumeRepository = volumeRepository;
+        this.mangaRepository = mangaRepository;
+    }
+
+    public List<VolumeResponseDTO> getAll(){
+        return volumeRepository.findAll()
+                .stream()
+                .map(volume -> new VolumeResponseDTO(
+                        volume.getId(),
+                        volume.getNumero(),
+                        volume.getCodigoDeBarras(),
+                        volume.getIsbn(),
+                        volume.getManga().getId(),
+                        volume.getImagemUrl()
+                )).toList();
+    }
+
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
@@ -1,12 +1,16 @@
 package dev.flmelo.mangakeeper.backend.service;
 
 import dev.flmelo.mangakeeper.backend.dto.volume.VolumeResponseDTO;
+import dev.flmelo.mangakeeper.backend.entity.Volume;
 import dev.flmelo.mangakeeper.backend.repository.MangaRepository;
 import dev.flmelo.mangakeeper.backend.repository.VolumeRepository;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class VolumeService {
@@ -31,4 +35,19 @@ public class VolumeService {
                 )).toList();
     }
 
+    public VolumeResponseDTO getById(Long id){
+        Optional<Volume> volumeById = volumeRepository.findById(id);
+        if (volumeById.isEmpty()){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Volume não encontrado.");
+        }
+        Volume v = volumeById.get();
+        return new VolumeResponseDTO(
+                v.getId(),
+                v.getNumero(),
+                v.getCodigoDeBarras(),
+                v.getIsbn(),
+                v.getManga().getId(),
+                v.getImagemUrl()
+        );
+    }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
@@ -85,7 +85,7 @@ public class VolumeService {
         if (volumeById.isEmpty()){
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Volume não encontrado.");
         }
-        Volume volumeAtualizado = new Volume();
+        Volume volumeAtualizado = volumeById.get();
         if (request.numero() != null){
             volumeAtualizado.setNumero(request.numero());
         }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
@@ -50,4 +50,12 @@ public class VolumeService {
                 v.getImagemUrl()
         );
     }
+
+    public void delete(Long id){
+        Optional<Volume> volumeById = volumeRepository.findById(id);
+        if (volumeById.isEmpty()){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Volume não encontrado.");
+        }
+        volumeRepository.deleteById(id);
+    }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/VolumeService.java
@@ -51,6 +51,8 @@ public class VolumeService {
         );
     }
 
+    public VolumeResponseDTO()
+
     public void delete(Long id){
         Optional<Volume> volumeById = volumeRepository.findById(id);
         if (volumeById.isEmpty()){


### PR DESCRIPTION
## O que foi feito
- CRUD de volumes
- Endpoint de criação, listagem, atualização e deleção

## Estrutura
- Controller para endpoints REST
- Service com regras de negócio
- Repository com JPA
- DTOs de entrada e saída

## Regras aplicadas
- Validação com Bean Validation (@NotBlank, @Positive, etc.)
- Associação obrigatória com manga
- Normalização de strings (trim)

## Como testar
1. Criar uma manga no banco
2. Fazer POST /volumes
3. Testar GET, PATCH, DELETE
4. Validar erros (ex: numero <= 0)

## Observações
- Atualização parcial implementada (PATCH)

## Issue relacionada
#8 