### PR TITLE
Feat: Implementar handler global exception

### DIFF
--- a/src/main/java/dev/flmelo/mangakeeper/backend/exceptions/LikeAlreadyExistsException.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/exceptions/LikeAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package dev.flmelo.mangakeeper.backend.exceptions;
+
+public class LikeAlreadyExistsException extends RuntimeException {
+    public LikeAlreadyExistsException() {super("Este usuario já curtiu essa coleção.");}
+
+    public LikeAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestErrorMessage.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestErrorMessage.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public class RestErrorMessage {
-    private HttpStatus status;
+    private HttpStatus error;
+    private Integer status;
     private String message;
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestExceptionHandler.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/infra/RestExceptionHandler.java
@@ -13,42 +13,56 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     @ExceptionHandler(UserNotFoundException.class)
     private ResponseEntity<RestErrorMessage> userNotFoundHandler(UserNotFoundException exception){
         HttpStatus status = HttpStatus.NOT_FOUND;
-        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        Integer statusCode = status.value();
+        RestErrorMessage errorResponse = new RestErrorMessage(status,statusCode, exception.getMessage());
         return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(UserAlreadyExistsException.class)
     private ResponseEntity<RestErrorMessage> userAlreadyExistsHandler(UserAlreadyExistsException exception){
         HttpStatus status = HttpStatus.CONFLICT;
-        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        Integer statusCode = status.value();
+        RestErrorMessage errorResponse = new RestErrorMessage(status,statusCode, exception.getMessage());
         return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(CollectionNotFoundException.class)
     private ResponseEntity<RestErrorMessage> colletionNotFoundHandler(CollectionNotFoundException exception){
         HttpStatus status = HttpStatus.NOT_FOUND;
-        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        Integer statusCode = status.value();
+        RestErrorMessage errorResponse = new RestErrorMessage(status,statusCode, exception.getMessage());
         return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(InvalidCollectionNameException.class)
     private ResponseEntity<RestErrorMessage> invalidCollectionNameHandler(InvalidCollectionNameException exception){
         HttpStatus status = HttpStatus.BAD_REQUEST;
-        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        Integer statusCode = status.value();
+        RestErrorMessage errorResponse = new RestErrorMessage(status,statusCode, exception.getMessage());
         return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(MangaNotFoundException.class)
     private ResponseEntity<RestErrorMessage> mangaNotFoundHandler(MangaNotFoundException exception){
         HttpStatus status = HttpStatus.NOT_FOUND;
-        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        Integer statusCode = status.value();
+        RestErrorMessage errorResponse = new RestErrorMessage(status,statusCode, exception.getMessage());
         return ResponseEntity.status(status).body(errorResponse);
     }
 
     @ExceptionHandler(VolumeNotFoundException.class)
     private ResponseEntity<RestErrorMessage> volumeNotFoundHandler(VolumeNotFoundException exception){
         HttpStatus status = HttpStatus.NOT_FOUND;
-        RestErrorMessage errorResponse = new RestErrorMessage(status, exception.getMessage());
+        Integer statusCode = status.value();
+        RestErrorMessage errorResponse = new RestErrorMessage(status,statusCode, exception.getMessage());
+        return ResponseEntity.status(status).body(errorResponse);
+    }
+
+    @ExceptionHandler(LikeAlreadyExistsException.class)
+    private ResponseEntity<RestErrorMessage> likeAlreadyExistsException(LikeAlreadyExistsException exception){
+        HttpStatus status = HttpStatus.CONFLICT;
+        Integer statusCode = status.value();
+        RestErrorMessage errorResponse = new RestErrorMessage(status,statusCode, exception.getMessage());
         return ResponseEntity.status(status).body(errorResponse);
     }
 }

--- a/src/main/java/dev/flmelo/mangakeeper/backend/service/CurtidaService.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/service/CurtidaService.java
@@ -8,6 +8,7 @@ import dev.flmelo.mangakeeper.backend.entity.Colecao;
 import dev.flmelo.mangakeeper.backend.entity.Curtida;
 import dev.flmelo.mangakeeper.backend.entity.Usuario;
 import dev.flmelo.mangakeeper.backend.exceptions.CollectionNotFoundException;
+import dev.flmelo.mangakeeper.backend.exceptions.LikeAlreadyExistsException;
 import dev.flmelo.mangakeeper.backend.exceptions.UserNotFoundException;
 import dev.flmelo.mangakeeper.backend.repository.ColecaoRepository;
 import dev.flmelo.mangakeeper.backend.repository.CurtidaRepository;
@@ -35,7 +36,7 @@ public class CurtidaService {
     public void curtirColecao(Long usuarioId, Long colecaoId) {
         SimpleEntry<Usuario, Colecao> res = validarUsuarioEColecaoExistentes(usuarioId, colecaoId);
         if (curtidaRepository.existsByUsuarioIdAndColecaoId(usuarioId, colecaoId)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "Este usuario já curtiu essa coleção.");
+            throw new LikeAlreadyExistsException();
         }
         Usuario usuario = res.getKey();
         Colecao colecao = res.getValue();


### PR DESCRIPTION
# Implementar Handler Global de Exceções

## 📌 Objetivo

Centralizar o tratamento de erros da aplicação, garantindo respostas padronizadas, consistentes e mais legíveis para o cliente da API.

---

## 🧱 O que foi feito

* Criação de um **Handler Global** utilizando `@ControllerAdvice`
* Padronização das respostas de erro com a classe `RestErrorMessage`
* Tratamento centralizado de exceções específicas do domínio
* Definição de códigos HTTP apropriados para cada tipo de erro

---

## ⚙️ Estrutura

### 🔹 Handler Global

* Intercepta exceções lançadas pela aplicação
* Converte exceções em respostas HTTP padronizadas

### 🔹 Classe de resposta de erro

```json
{
    "error": "CONFLICT",
    "status": 409,
    "message": "Este usuario já curtiu essa coleção."
}
```

---

## 🚨 Exceções tratadas

* `CollectionNotFoundException` → 404 Not Found
* `MangaNotFoundException` → 404 Not Found
* `UserNotFoundException` → 404 Not Found
* `VolumeNotFoundException` → 404 Not Found
* `UserAlreadyExistsException` → 409 Conflict
* `LikeAlreadyExistsException` → 409 Conflict
* `InvalidCollectionNameException` → 400 Bad Request

---

## ✅ Benefícios

* Remove necessidade de `try/catch` nos controllers
* Garante consistência nas respostas de erro
* Melhora a previsibilidade para quem consome a API
* Facilita manutenção e evolução do código

---

## 🧠 Decisões de implementação

* Uso de códigos HTTP semânticos (400, 404, 409, 500)
* Separação de responsabilidades (Controller → Service → Handler)
* Padronização do payload de erro

---

## 🧪 Como testar

* Realizar requisições para recursos inexistentes
* Validar retorno de erros de negócio (ex: curtida duplicada)
* Verificar padrão de resposta (`status` + `message`)

---

## 📎 Observação

A implementação cobre os principais cenários de erro atuais e está preparada para evolução conforme novas regras de negócio forem adicionadas.

## Issue 
Closes #24 