### PR TITLE
feat(cors): adiciona política de CORS configurável com Spring Security

### DIFF
--- a/src/main/java/dev/flmelo/mangakeeper/backend/config/security/WebSecurityConfig.java
+++ b/src/main/java/dev/flmelo/mangakeeper/backend/config/security/WebSecurityConfig.java
@@ -1,6 +1,7 @@
 package dev.flmelo.mangakeeper.backend.config.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -14,10 +15,18 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @EnableWebSecurity
 @Configuration
 public class WebSecurityConfig {
+
+    @Value("${api.configure.cors}")
+    private String FRONTEND;
 
     @Autowired
     private SecurityFilter securityFilter;
@@ -26,6 +35,7 @@ public class WebSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
         http
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests((auth) -> auth
                                 .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
@@ -33,6 +43,7 @@ public class WebSecurityConfig {
                                 .requestMatchers(HttpMethod.GET, "/usuarios").hasRole("ADMIN")
                                 .requestMatchers("/swagger-ui.html","/swagger-ui/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/colecoes/**", "/mangas/**", "/volumes/**", "/curtidas/colecao/**", "/usuarios/**").permitAll()
+                                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                 .requestMatchers(HttpMethod.DELETE, "/**").authenticated()
                                 .requestMatchers(HttpMethod.PATCH, "/**").authenticated()
                                 .anyRequest().authenticated()
@@ -49,6 +60,20 @@ public class WebSecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
+    }
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(){
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(List.of(FRONTEND));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     /* Usuario em Memoria *

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,4 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialec
 spring.jpa.properties.hibernate.format_sql=true
 
 api.security.token.secret=${JWT_SECRET:my-secret-key}
+api.configure.cors=${HOST_CORS:http://localhost:4200}


### PR DESCRIPTION
## Objetivo

Adicionar configuração de CORS para permitir integração segura entre frontend Angular e API Spring Boot.

## Alterações realizadas

* Adicionado `CorsConfigurationSource`
* Integração do CORS com `SecurityFilterChain`
* Configuração de métodos HTTP permitidos
* Configuração de headers permitidos
* Suporte a credentials
* Configuração via variável de ambiente (`HOST_CORS`)
* Liberação de origem local para desenvolvimento (`localhost:4200`)

## Resultado

Frontend Angular consegue consumir a API corretamente em ambiente local respeitando políticas de segurança do navegador.


### Issue 

Closes #13 